### PR TITLE
fix: OpenCode commands naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Thumbs.db
 *.tmp
 *.temp
 *~
+
+# AI tools
+.opencode

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ openspdd --tool codex <command>
 | OpenCode       | `.opencode/`, `opencode.json`                                 | `.opencode/commands/`      |
 | Codex          | `.codex/`, `.codex/config.toml`                               | `.agents/skills/`          |
 
+OpenCode command naming follows the markdown filename (for example, `spdd-analysis.md` maps to `/spdd-analysis`). To avoid command alias conflicts in OpenCode, generated OpenCode command files intentionally omit frontmatter `name`.
+
 ### Codex Skills
 
 Codex generates project-scoped skill bundles under `.agents/skills/<id>/SKILL.md` (a cross-vendor open-standard directory; see [agentskills.io](https://agentskills.io/)) — not flat command files. Inside the Codex CLI / IDE extension, invoke SPDD commands with `$spdd-analysis` (etc.) or via the `/skills` menu — **not** `/spdd-analysis`. Generated skills are configured for explicit-only invocation by default (`agents/openai.yaml` sets `allow_implicit_invocation: false`); pass `--allow-implicit` to opt into Codex's auto-invocation behavior. **Trust-model note**: on some Codex versions skills from untrusted projects are silently ignored — if the skills do not appear after generation, confirm the project is marked trusted in your `~/.codex/config.toml` (see [openai/codex#9752](https://github.com/openai/codex/issues/9752)). If the skills still do not appear after a generate run, restart Codex (per official docs).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -266,6 +266,8 @@ openspdd --tool codex <command>
 | OpenCode       | `.opencode/`, `opencode.json`                                 | `.opencode/commands/`      |
 | Codex          | `.codex/`, `.codex/config.toml`                               | `.agents/skills/`          |
 
+OpenCode 的命令名由 Markdown 文件名决定（例如 `spdd-analysis.md` 对应 `/spdd-analysis`）。为避免 OpenCode 中的命令别名冲突，生成到 OpenCode 的命令文件会有意省略 frontmatter `name` 字段。
+
 ### Codex Skills
 
 Codex 会以项目级 skill 包的形式生成命令模板，输出到 `.agents/skills/<id>/SKILL.md`（这是一个跨厂商的开放标准目录，详见 [agentskills.io](https://agentskills.io/)），而不是扁平的命令文件。在 Codex CLI / IDE 扩展中，请使用 `$spdd-analysis` 等形式或通过 `/skills` 菜单调用 SPDD 命令，**不要**使用 `/spdd-analysis`。生成的 skill 默认仅支持显式调用（`agents/openai.yaml` 中 `allow_implicit_invocation: false`）；如需让 Codex 自动隐式调用，请在生成时附加 `--allow-implicit`。**信任模型说明**：在部分 Codex 版本中，未受信任项目的 skill 会被静默忽略，如果生成后 skill 没有出现，请确认你的 `~/.codex/config.toml` 中已将该项目标记为受信任（参考 [openai/codex#9752](https://github.com/openai/codex/issues/9752)）。如果 skill 仍未出现，请按官方文档所述重启 Codex。

--- a/internal/templates/flat_strategy.go
+++ b/internal/templates/flat_strategy.go
@@ -34,9 +34,16 @@ func (s *FlatMarkdownStrategy) GenerateOne(workingDir string, tmpl TemplateMeta,
 		targetDir = filepath.Join(workingDir, configDir)
 	}
 
+	targetPath := filepath.Join(targetDir, tmpl.ID+".md")
+	adapter := OpenCodeTemplateAdapter{}
+	if adapter.IsApplicable(s.tool) {
+		normalized := adapter.NormalizeForOpenCode(tmpl)
+		return []GenerateResult{s.manager.generateWithContent(targetPath, normalized, force)}
+	}
+
 	req := GenerateRequest{
 		TemplateName: tmpl.Name,
-		TargetPath:   filepath.Join(targetDir, tmpl.ID+".md"),
+		TargetPath:   targetPath,
 		Force:        force,
 	}
 	return []GenerateResult{s.manager.Generate(req)}

--- a/internal/templates/manager.go
+++ b/internal/templates/manager.go
@@ -196,7 +196,11 @@ func (m *EmbeddedTemplateManager) Generate(req GenerateRequest) GenerateResult {
 		}
 	}
 
-	if _, err := os.Stat(targetPath); err == nil && !req.Force {
+	return m.generateWithContent(targetPath, template.Content, req.Force)
+}
+
+func (m *EmbeddedTemplateManager) generateWithContent(targetPath, content string, force bool) GenerateResult {
+	if _, err := os.Stat(targetPath); err == nil && !force {
 		return GenerateResult{
 			Success:  false,
 			FilePath: targetPath,
@@ -214,7 +218,7 @@ func (m *EmbeddedTemplateManager) Generate(req GenerateRequest) GenerateResult {
 		}
 	}
 
-	if err := os.WriteFile(targetPath, []byte(template.Content), 0644); err != nil {
+	if err := os.WriteFile(targetPath, []byte(content), 0644); err != nil {
 		return GenerateResult{
 			Success: false,
 			Message: "failed to write file: " + targetPath,

--- a/internal/templates/opencode_adapter.go
+++ b/internal/templates/opencode_adapter.go
@@ -1,0 +1,40 @@
+package templates
+
+import (
+	"strings"
+
+	"github.com/gszhangwei/open-spdd/internal/detector"
+)
+
+type OpenCodeTemplateAdapter struct{}
+
+func (a OpenCodeTemplateAdapter) IsApplicable(tool detector.AIToolType) bool {
+	return tool == detector.OpenCode
+}
+
+func (a OpenCodeTemplateAdapter) NormalizeForOpenCode(tmpl TemplateMeta) string {
+	return a.StripFrontmatterName(tmpl.Content)
+}
+
+func (a OpenCodeTemplateAdapter) StripFrontmatterName(content string) string {
+	if !strings.HasPrefix(content, "---") {
+		return content
+	}
+
+	parts := strings.SplitN(content, "---", 3)
+	if len(parts) < 3 {
+		return content
+	}
+
+	lines := strings.Split(parts[1], "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "name:") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+
+	return "---" + strings.Join(filtered, "\n") + "---" + parts[2]
+}

--- a/spdd/analysis/GGQPA-XXX-202605121442-[Analysis]-opencode-command-name-frontmatter.md
+++ b/spdd/analysis/GGQPA-XXX-202605121442-[Analysis]-opencode-command-name-frontmatter.md
@@ -1,0 +1,67 @@
+# SPDD Analysis: OpenCode Command Naming Without Frontmatter Name Field
+
+## Original Business Requirement
+openspdd generates commands for the AI tool `opencode` in the way commands exists in the opnecode UI as //spdd-* but should be just /spdd-*; this happens because in generated files there is a field "name" and it is populated incorrectly (like "name: /spdd-analysis"); the right approach for the `opnecode` will be do not use the "name" field at all -- from the documentation "... The markdown file name becomes the command name. For example, test.md lets you run: /test ..."
+
+## Domain Concept Identification
+
+### Existing Concepts (from codebase)
+- `TemplateMeta` + `ParseFrontmatter`: shared template metadata model where `name`, `id`, `category`, and `description` are parsed and retained across tools; this currently preserves slash-style names from core templates.
+- `FlatMarkdownStrategy`: default generation strategy used by OpenCode that writes raw template content to `.opencode/commands/<id>.md`; it relies on filename from `id` while still carrying frontmatter content verbatim.
+- `EmbeddedTemplateManager` + embedded `data/core/*.md`: central source of SPDD command content, with core templates currently including `name: /spdd-*` frontmatter.
+- `AIToolType.OpenCode`: OpenCode is already a first-class tool, mapped to `.opencode/commands` and selected via tool detection/flags.
+- Existing OpenCode command artifacts under `.opencode/commands/`: generated files currently include `name: /spdd-*`, confirming parity between embedded core frontmatter and generated OpenCode command files.
+
+### New Concepts Required
+- `OpenCode-specific frontmatter compatibility boundary`: a tool-specific policy that treats command identity as filename-only and avoids `name` frontmatter emission for OpenCode command files.
+- `Frontmatter normalization mode for OpenCode flat commands`: a generation-time transformation concept that keeps reusable command body content while adapting incompatible metadata fields for OpenCode runtime behavior.
+
+### Key Business Rules
+- `Filename is command identity in OpenCode`: command invocation must be derived from markdown filename, not frontmatter `name`.
+- `No slash duplication in OpenCode UI`: generated commands must appear as `/spdd-*`, never `//spdd-*`.
+- `Tool-specific behavior must not regress other tools`: changes for OpenCode must preserve current behavior for Cursor/Claude/Antigravity/Copilot/Codex outputs.
+- `SPDD command corpus remains reusable`: core SPDD command intent/content should stay centrally managed rather than duplicating per-tool command text.
+
+## Strategic Approach
+
+### Solution Direction
+- Keep the current architecture (embedded core templates + per-tool generation strategies), and introduce an OpenCode-specific output compatibility rule at generation time so OpenCode receives filename-driven commands without `name` frontmatter while other tools continue using existing template semantics.
+
+### Key Design Decisions
+- `Where to adapt`: adapt at generation strategy/output boundary, not by rewriting core template source files globally -> preserves shared template reuse and limits blast radius.
+- `Scope of adaptation`: apply only to OpenCode command generation path -> prevents unintended behavior changes for tools that may rely on or tolerate existing frontmatter.
+- `Metadata handling`: remove or neutralize `name` for OpenCode artifacts while retaining useful descriptive metadata where compatible -> balances OpenCode command correctness with maintainability.
+- `Validation posture`: codify expected OpenCode command shape in tests (no command-identity conflict fields, filename-derived command works) -> prevents future regressions from template/content evolution.
+
+### Alternatives Considered
+- `Edit all core templates to remove name permanently`: rejected because it forces cross-tool behavioral change and couples OpenCode-specific runtime rules to shared source content.
+- `Keep current files and rely on user workaround`: rejected because it does not satisfy the requirement to produce correct `/spdd-*` commands automatically.
+- `Fork a full OpenCode-specific template set`: rejected because it duplicates command content and increases long-term drift/maintenance risk.
+
+## Risk & Gap Analysis
+
+### Requirement Ambiguities
+- `Exact failure mechanism in OpenCode`: requirement observes `//spdd-*` behavior but does not define whether OpenCode prepends slash to `name` or displays both filename/name concurrently; this affects strict formatting expectations for generated frontmatter.
+- `Allowed frontmatter subset`: requirement explicitly says not to use `name`, but does not confirm whether `id`/`category` are harmless, ignored, or potentially problematic in OpenCode command files.
+- `Coverage scope`: unclear whether fix is required only for core SPDD commands or also optional templates generated for OpenCode.
+
+### Edge Cases
+- `Existing generated files with stale name fields`: previously generated `.opencode/commands/*.md` may continue producing wrong command labels unless regenerated.
+- `Mixed-tool repos`: projects generating for multiple tools need OpenCode-specific adaptation without altering files intended for other assistant ecosystems.
+- `Single-template generation vs generate-all`: both command paths must enforce the same OpenCode compatibility behavior.
+- `Future template additions`: newly added templates with `name` frontmatter must automatically follow OpenCode compatibility rules.
+
+### Technical Risks
+- `Cross-tool regression risk`: changing shared parsing/model behavior (`TemplateMeta.Name`, `GetByName`) can break command selection and tests; mitigation direction is strategy-local transformation rather than global parser changes.
+- `Behavior drift between strategies`: OpenCode uses flat generation while Codex uses skill transformation; inconsistent metadata handling across strategies can reintroduce bugs; mitigation direction is explicit per-strategy contract tests.
+- `Backward compatibility with list/get semantics`: `GetByName("/spdd-analysis")` is used in tests and UX flows; removing source-level `name` fields globally could impact lookup expectations.
+
+### Acceptance Criteria Coverage
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 1 | OpenCode generated commands appear as `/spdd-*`, not `//spdd-*` | Yes | Requires OpenCode output to avoid conflicting `name` semantics. |
+| 2 | OpenCode command identity is filename-driven per OpenCode docs | Yes | Existing filename generation (`<id>.md`) already aligns. |
+| 3 | Generated OpenCode command files do not rely on `name` frontmatter | Yes | Requires OpenCode-specific frontmatter adaptation. |
+| 4 | Existing non-OpenCode tool outputs remain unchanged | Partial | Must be protected through scoped strategy changes and regression tests. |
+| 5 | Behavior is consistent for both single-template and generate-all flows | Yes | Both flows already converge through strategy abstraction; compatibility rule must apply in both paths. |
+| 6 | Optional templates generated for OpenCode follow same command naming rule | Partial | Requirement does not explicitly mention optional templates; recommended to include for consistency. |

--- a/spdd/prompt/GGQPA-XXX-202605121451-[Fix]-service-opencode-command-naming.md
+++ b/spdd/prompt/GGQPA-XXX-202605121451-[Fix]-service-opencode-command-naming.md
@@ -1,0 +1,217 @@
+# Fix OpenCode Command Name Resolution in Generated Templates
+
+## Requirements
+Implement OpenCode-specific command generation that preserves shared SPDD template reuse while ensuring OpenCode command invocation is determined only by markdown filename, preventing `//spdd-*` command rendering and avoiding regressions in non-OpenCode outputs.
+
+## Entities
+```mermaid
+classDiagram
+direction TB
+
+class TemplateMeta {
+    +string Name
+    +string ID
+    +string Category
+    +string Description
+    +string Content
+}
+
+class FlatMarkdownStrategy {
+    +AIToolType tool
+    +EmbeddedTemplateManager manager
+    +GenerateAll(string workingDir, bool force) []GenerateResult
+    +GenerateOne(string workingDir, TemplateMeta tmpl, bool force) []GenerateResult
+}
+
+class OpenCodeTemplateAdapter {
+    +IsApplicable(AIToolType tool) bool
+    +NormalizeForOpenCode(TemplateMeta tmpl) string
+    +StripFrontmatterName(string content) string
+}
+
+class GenerateRequest {
+    +string TemplateName
+    +string TargetPath
+    +bool Force
+}
+
+class GenerateResult {
+    +bool Success
+    +string FilePath
+    +string Message
+    +error Error
+}
+
+class EmbeddedTemplateManager {
+    +Generate(GenerateRequest req) GenerateResult
+    +generateWithContent(string targetPath, string content, bool force) GenerateResult
+    +GetByName(string name) (TemplateMeta, error)
+}
+
+FlatMarkdownStrategy "1" --> "1" EmbeddedTemplateManager : delegates generation
+FlatMarkdownStrategy "1" --> "0..1" OpenCodeTemplateAdapter : applies compatibility rule
+OpenCodeTemplateAdapter --> TemplateMeta : reads source template
+OpenCodeTemplateAdapter --> EmbeddedTemplateManager : normalized content write
+GenerateRequest --> EmbeddedTemplateManager : standard write flow
+EmbeddedTemplateManager --> GenerateResult : maps operation outcome
+```
+
+## Approach
+1. Generation Compatibility Strategy:
+   - Add a tool-scoped normalization step in the OpenCode flat markdown generation path.
+   - Keep embedded core templates unchanged as the single source of SPDD command content.
+   - Remove command-identity-conflicting frontmatter (`name`) only for OpenCode output artifacts.
+
+2. Technical Implementation:
+   - Extend the flat generation workflow to support OpenCode-only transformed content write.
+   - Preserve existing filename generation (`tmpl.ID + ".md"`) because OpenCode command identity is filename-derived.
+   - Maintain current strategy dispatch model (`StrategyFor`) and avoid broad parser/model refactors.
+   - Use existing error propagation style in `GenerateResult` and preserve current overwrite safeguards (`--force`) via shared manager write path.
+
+3. Business Logic:
+   - Core rule: OpenCode command metadata must not override filename-based command naming.
+   - Ensure consistent behavior for both single-template generation and generate-all bulk generation.
+   - Preserve backward-compatible behavior for Cursor, Claude Code, Antigravity, GitHub Copilot, and Codex outputs.
+
+## Structure
+
+### Inheritance Relationships
+1. `GenerationStrategy` interface defines multi-template and single-template generation contracts.
+2. `FlatMarkdownStrategy` implements `GenerationStrategy` for markdown command-file tools.
+3. `OpenCodeTemplateAdapter` is a focused compatibility component used by `FlatMarkdownStrategy` when tool is OpenCode.
+4. Existing domain errors continue using current error model (`GenerateResult.Error`) without introducing new exception hierarchies.
+
+### Dependencies
+1. `cmd/generate.go` calls `templates.StrategyFor(...).GenerateAll/GenerateOne`.
+2. `FlatMarkdownStrategy` depends on `EmbeddedTemplateManager` for standard generation and shared content writing.
+3. `FlatMarkdownStrategy` depends on `AIToolType` to branch OpenCode normalization behavior and on `OpenCodeTemplateAdapter` for frontmatter transformation.
+4. Template tests depend on generated file content contract for OpenCode command files.
+
+### Layered Architecture
+1. CLI Layer: resolves active tool, routes generation requests, and reports results.
+2. Strategy Layer: applies tool-aware generation behavior and compatibility adaptation.
+3. Template Management Layer: resolves embedded templates and manages write operations.
+4. Embedded Asset Layer: stores reusable core command markdown templates.
+5. Validation/Test Layer: asserts tool-specific output contracts and regression boundaries.
+
+## Operations
+
+### Update Strategy Component - `FlatMarkdownStrategy`
+1. Responsibility: apply OpenCode-specific content normalization before writing command files.
+2. Attributes:
+   - `tool`: `detector.AIToolType` - active tool target controlling compatibility behavior.
+   - `manager`: `*EmbeddedTemplateManager` - shared template provider and writer.
+3. Methods:
+   - `GenerateOne(workingDir string, tmpl TemplateMeta, force bool) []GenerateResult`
+     - Logic:
+       - Resolve target directory from `tool.GetConfigDir()`.
+       - Build target filename as `<tmpl.ID>.md` for all tools.
+       - If tool is OpenCode, normalize content via `OpenCodeTemplateAdapter.NormalizeForOpenCode` and write via `EmbeddedTemplateManager.generateWithContent`.
+       - If tool is not OpenCode, keep current generation flow unchanged (`GenerateRequest` -> `EmbeddedTemplateManager.Generate`).
+       - Return success/failure in existing `GenerateResult` format.
+   - `GenerateAll(workingDir string, force bool) []GenerateResult`
+     - Logic:
+       - List all available templates for active tool.
+       - Iterate templates and call the updated `GenerateOne` path so normalization is uniformly applied.
+       - Preserve current aggregate result behavior.
+4. Annotations: none (Go package-level strategy implementation).
+5. Constraints:
+   - Do not change behavior for non-OpenCode tools.
+   - Do not alter filename mapping logic.
+
+### Create/Update Compatibility Helper - `OpenCodeTemplateAdapter`
+1. Responsibility: transform template markdown content to OpenCode-compatible frontmatter.
+2. Attributes:
+   - stateless adapter implementation (no fields).
+3. Methods:
+   - `IsApplicable(tool detector.AIToolType) bool`
+      - Logic:
+        - Return true only when tool equals `detector.OpenCode`.
+   - `NormalizeForOpenCode(tmpl TemplateMeta) string`
+      - Logic:
+        - Delegate to `StripFrontmatterName(tmpl.Content)`.
+        - Return transformed markdown ready for file write.
+   - `StripFrontmatterName(content string) string`
+      - Logic:
+        - If content does not start with `---`, return original content.
+        - Split content using `strings.SplitN(content, "---", 3)`; if invalid frontmatter shape, return original content.
+        - Remove only lines whose trimmed value starts with `name:` from the frontmatter block.
+        - Rebuild content with frontmatter delimiters and original markdown body unchanged.
+        - Return original content unchanged when no frontmatter is present.
+4. Annotations: none.
+5. Constraints:
+   - Must be idempotent (re-applying should not alter output again).
+   - Must not remove `name` occurrences in body text.
+
+### Update Template Write Flow - `EmbeddedTemplateManager`
+1. Responsibility: support strategy-provided content writes without breaking existing template lookup APIs.
+2. Attributes:
+   - existing request/result models remain primary contract.
+3. Methods:
+   - `generateWithContent(targetPath, content, force) GenerateResult`:
+     - enforce overwrite checks (`--force`), create parent directory, and write provided content.
+     - return existing `GenerateResult` success/error contract.
+   - `Generate(req) GenerateResult`:
+     - preserve template lookup semantics.
+     - delegate write behavior to `generateWithContent(targetPath, template.Content, req.Force)`.
+4. Annotations: none.
+5. Constraints:
+   - Keep `GetByName` and metadata parsing behavior intact for current tests and command selection.
+   - Preserve file existence checks and `--force` semantics.
+
+### Extend Tests - OpenCode Output Contract
+1. Responsibility: codify the fix and guard against cross-tool regressions.
+2. Attributes:
+   - test fixtures for OpenCode target directory and generated markdown snapshots.
+3. Methods:
+   - `TestFlatMarkdownStrategy_OpenCodeGenerateOne_RemovesFrontmatterName`:
+      - file path is `.opencode/commands/<id>.md`
+      - frontmatter does not contain `name:` key
+      - markdown body remains intact.
+   - `TestFlatMarkdownStrategy_OpenCodeGenerateAll_RemovesFrontmatterName`:
+     - all generated command files for OpenCode omit `name:`.
+   - `TestFlatMarkdownStrategy_NonOpenCode_PreservesFrontmatterName`:
+     - non-OpenCode targets (Cursor) preserve `name:`.
+   - `TestFlatMarkdownStrategy_OpenCodeForceRegeneration_IsIdempotent`:
+     - regeneration with `--force` keeps valid frontmatter delimiters and does not reintroduce `name:`.
+4. Annotations: Go `testing` package with table-driven tests consistent with existing style.
+5. Constraints:
+   - Tests must be deterministic and filesystem-local (`t.TempDir()`).
+   - Do not rely on interactive CLI behavior.
+
+### Update Documentation Surface - OpenCode Command Semantics
+1. Responsibility: align user expectations with generated output behavior.
+2. Attributes:
+   - `README.md`, `README.zh-CN.md`, and relevant OpenCode template notes.
+3. Methods:
+   - Document that OpenCode command invocation uses markdown filename.
+   - Document that OpenCode-generated command files intentionally omit frontmatter `name` to avoid command alias conflicts.
+4. Annotations: none.
+5. Constraints:
+   - Keep wording additive and scoped to OpenCode behavior.
+
+## Norms
+1. Annotation Standards: keep Go code idiomatic with explicit package boundaries and minimal exported surface.
+2. Dependency Injection: continue constructor-free lightweight composition used by strategies and managers.
+3. Exception Handling:
+   - Preserve current `GenerateResult`-based error propagation pattern.
+   - Return actionable error messages for file write or parsing failures.
+   - Do not introduce panics for malformed template content.
+4. Data Validation: validate frontmatter boundaries before mutation; fallback safely to original content when structure is absent.
+5. Logging: keep existing CLI renderer messaging patterns; do not add verbose output in library code.
+6. Documentation Standards: update English and Chinese docs together when user-visible behavior changes.
+7. Strategy Scope: keep OpenCode adaptation strategy-local (`FlatMarkdownStrategy` + `OpenCodeTemplateAdapter`) and route file writes through shared manager write logic.
+
+## Safeguards
+1. Functional Constraints: OpenCode-generated commands must render as `/spdd-*` and must not include frontmatter `name` key in generated files.
+2. Performance Constraints: content normalization should be linear in file size and add negligible overhead to batch generation.
+3. Security Constraints: no external I/O beyond target generation paths; no execution of template content.
+4. Integration Constraints: strategy dispatch remains tool-based and must not alter Copilot or Codex specialized flows.
+5. Business Rule Constraints: shared core template source remains unchanged; OpenCode adaptation occurs at generation boundary only.
+6. Exception Handling Constraints:
+   - All generation failures must return `GenerateResult{Success:false}` with non-nil error.
+   - Error messages must not leak unrelated filesystem internals.
+   - Partial generation failures in generate-all must be isolated per template.
+7. Technical Constraints: avoid changing `TemplateMeta.Name` semantics globally to protect `GetByName("/spdd-*")` compatibility.
+8. Data Constraints: only remove top-level frontmatter `name`; preserve `id`, `category`, `description`, and markdown body verbatim.
+9. API Constraints: CLI command signatures and flags (`generate`, `--tool`, `--force`) remain backward-compatible.

--- a/tests/templates/opencode_flat_strategy_test.go
+++ b/tests/templates/opencode_flat_strategy_test.go
@@ -1,0 +1,133 @@
+package templates_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gszhangwei/open-spdd/internal/detector"
+	"github.com/gszhangwei/open-spdd/internal/templates"
+)
+
+func TestFlatMarkdownStrategy_OpenCodeGenerateOne_RemovesFrontmatterName(t *testing.T) {
+	tempDir := t.TempDir()
+	mgr := templates.NewEmbeddedTemplateManager()
+
+	tmpl, err := mgr.GetByName("/spdd-analysis")
+	if err != nil {
+		t.Fatalf("GetByName(/spdd-analysis) error = %v", err)
+	}
+
+	results := templates.StrategyFor(detector.OpenCode, mgr).GenerateOne(tempDir, tmpl, false)
+	if len(results) != 1 {
+		t.Fatalf("GenerateOne() returned %d results, want 1", len(results))
+	}
+	if !results[0].Success {
+		t.Fatalf("GenerateOne() failed: %s", results[0].Message)
+	}
+
+	path := filepath.Join(tempDir, ".opencode", "commands", tmpl.ID+".md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	content := string(raw)
+
+	if strings.Contains(content, "\nname:") || strings.HasPrefix(content, "name:") {
+		t.Fatalf("generated OpenCode template contains forbidden frontmatter name field")
+	}
+	if !strings.Contains(content, "id: "+tmpl.ID) {
+		t.Fatalf("generated OpenCode template missing id line")
+	}
+	if !strings.Contains(content, "Analyze a business requirement document") {
+		t.Fatalf("generated OpenCode template body was not preserved")
+	}
+}
+
+func TestFlatMarkdownStrategy_OpenCodeGenerateAll_RemovesFrontmatterName(t *testing.T) {
+	tempDir := t.TempDir()
+	mgr := templates.NewEmbeddedTemplateManager()
+
+	results := templates.StrategyFor(detector.OpenCode, mgr).GenerateAll(tempDir, false)
+	if len(results) == 0 {
+		t.Fatal("GenerateAll() returned no results")
+	}
+
+	for _, result := range results {
+		if !result.Success {
+			t.Fatalf("GenerateAll() failed for %s: %s", result.FilePath, result.Message)
+		}
+		raw, err := os.ReadFile(result.FilePath)
+		if err != nil {
+			t.Fatalf("read generated file %s: %v", result.FilePath, err)
+		}
+		content := string(raw)
+		if strings.Contains(content, "\nname:") || strings.HasPrefix(content, "name:") {
+			t.Fatalf("generated OpenCode template %s contains forbidden frontmatter name field", result.FilePath)
+		}
+	}
+}
+
+func TestFlatMarkdownStrategy_NonOpenCode_PreservesFrontmatterName(t *testing.T) {
+	tempDir := t.TempDir()
+	mgr := templates.NewEmbeddedTemplateManager()
+
+	tmpl, err := mgr.GetByName("/spdd-analysis")
+	if err != nil {
+		t.Fatalf("GetByName(/spdd-analysis) error = %v", err)
+	}
+
+	results := templates.StrategyFor(detector.Cursor, mgr).GenerateOne(tempDir, tmpl, false)
+	if len(results) != 1 {
+		t.Fatalf("GenerateOne() returned %d results, want 1", len(results))
+	}
+	if !results[0].Success {
+		t.Fatalf("GenerateOne() failed: %s", results[0].Message)
+	}
+
+	path := filepath.Join(tempDir, ".cursor", "commands", tmpl.ID+".md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	content := string(raw)
+
+	if !strings.Contains(content, "name: /spdd-analysis") {
+		t.Fatalf("non-OpenCode generation should preserve name field")
+	}
+}
+
+func TestFlatMarkdownStrategy_OpenCodeForceRegeneration_IsIdempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	mgr := templates.NewEmbeddedTemplateManager()
+
+	tmpl, err := mgr.GetByName("/spdd-analysis")
+	if err != nil {
+		t.Fatalf("GetByName(/spdd-analysis) error = %v", err)
+	}
+
+	first := templates.StrategyFor(detector.OpenCode, mgr).GenerateOne(tempDir, tmpl, false)
+	if len(first) != 1 || !first[0].Success {
+		t.Fatalf("first GenerateOne() failed: %+v", first)
+	}
+
+	second := templates.StrategyFor(detector.OpenCode, mgr).GenerateOne(tempDir, tmpl, true)
+	if len(second) != 1 || !second[0].Success {
+		t.Fatalf("second GenerateOne() with force failed: %+v", second)
+	}
+
+	path := filepath.Join(tempDir, ".opencode", "commands", tmpl.ID+".md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	content := string(raw)
+
+	if strings.Count(content, "---") < 2 {
+		t.Fatalf("frontmatter delimiters malformed after force regeneration")
+	}
+	if strings.Contains(content, "\nname:") || strings.HasPrefix(content, "name:") {
+		t.Fatalf("name field reappeared after force regeneration")
+	}
+}


### PR DESCRIPTION
How the commands in OpenCode looks if generated from the current main:
<img width="880" height="360" alt="image" src="https://github.com/user-attachments/assets/68c7695b-adf8-43b3-af5e-5d7f5e8197f8" />

After this fix:
<img width="950" height="518" alt="image" src="https://github.com/user-attachments/assets/31c5d4ab-c217-4529-a882-1cd77c0037be" />

Related to #5 


P.S. How are you forcing naming of SPDD-files? It is unclear from the documentation at the moment. For me it generates XXX instead of [006]