### PR TITLE
docs: fix spdd-generate reference to removed /spdd-context command

### DIFF
--- a/.cursor/commands/spdd-generate.md
+++ b/.cursor/commands/spdd-generate.md
@@ -191,24 +191,32 @@ Issue: "AgentService interface shouldn't contain business logic"
 - Always check for and fix linter errors after batch generation
 - Always commit prompt and code changes together
 
-**Integration with /spdd-context**
+**Integration with /spdd-analysis and /spdd-reasons-canvas**
 
-This command is the second phase of the SPDD workflow:
+This command is the third phase of the SPDD workflow:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                           SPDD Workflow                                  │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                          │
-│  Phase 1: /spdd-context                                                │
+│  Phase 1: /spdd-analysis                                               │
 │  ┌────────────────────────────────────────────────────────────────┐    │
-│  │ Requirement → Alignment → Abstraction → Structured Prompt      │    │
+│  │ Requirement → Alignment → Abstraction → Enriched Context       │    │
+│  │                                                                 │    │
+│  │ Output: Strategic context (business + domain + risks)          │    │
+│  └────────────────────────────────────────────────────────────────┘    │
+│                              │                                          │
+│                              ▼                                          │
+│  Phase 2: /spdd-reasons-canvas                                         │
+│  ┌────────────────────────────────────────────────────────────────┐    │
+│  │ Enriched Context → REASONS Canvas → Structured Prompt          │    │
 │  │                                                                 │    │
 │  │ Output: spdd/prompt/GGQPA-XXX-*.md (REASONS Canvas)           │    │
 │  └────────────────────────────────────────────────────────────────┘    │
 │                              │                                          │
 │                              ▼                                          │
-│  Phase 2: /spdd-generate                                               │
+│  Phase 3: /spdd-generate                                               │
 │  ┌────────────────────────────────────────────────────────────────┐    │
 │  │ Structured Prompt → Validate → Generate → Verify → Code        │    │
 │  │                                                                 │    │
@@ -216,7 +224,7 @@ This command is the second phase of the SPDD workflow:
 │  └────────────────────────────────────────────────────────────────┘    │
 │                              │                                          │
 │                              ▼                                          │
-│  Phase 3: Review & Iteration                                            │
+│  Phase 4: Review & Iteration                                            │
 │  ┌────────────────────────────────────────────────────────────────┐    │
 │  │ Issue Found → Update Prompt → Regenerate → Commit Together     │    │
 │  │                                                                 │    │

--- a/internal/templates/data/core/spdd-generate.md
+++ b/internal/templates/data/core/spdd-generate.md
@@ -189,24 +189,32 @@ Issue: "AgentService interface shouldn't contain business logic"
 - Always check for and fix linter errors after batch generation
 - Always commit prompt and code changes together
 
-**Integration with /spdd-context**
+**Integration with /spdd-analysis and /spdd-reasons-canvas**
 
-This command is the second phase of the SPDD workflow:
+This command is the third phase of the SPDD workflow:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                           SPDD Workflow                                  │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                          │
-│  Phase 1: /spdd-context                                                │
+│  Phase 1: /spdd-analysis                                               │
 │  ┌────────────────────────────────────────────────────────────────┐    │
-│  │ Requirement → Alignment → Abstraction → Structured Prompt      │    │
+│  │ Requirement → Alignment → Abstraction → Enriched Context       │    │
+│  │                                                                 │    │
+│  │ Output: Strategic context (business + domain + risks)          │    │
+│  └────────────────────────────────────────────────────────────────┘    │
+│                              │                                          │
+│                              ▼                                          │
+│  Phase 2: /spdd-reasons-canvas                                         │
+│  ┌────────────────────────────────────────────────────────────────┐    │
+│  │ Enriched Context → REASONS Canvas → Structured Prompt          │    │
 │  │                                                                 │    │
 │  │ Output: spdd/prompt/GGQPA-XXX-*.md (REASONS Canvas)           │    │
 │  └────────────────────────────────────────────────────────────────┘    │
 │                              │                                          │
 │                              ▼                                          │
-│  Phase 2: /spdd-generate                                               │
+│  Phase 3: /spdd-generate                                               │
 │  ┌────────────────────────────────────────────────────────────────┐    │
 │  │ Structured Prompt → Validate → Generate → Verify → Code        │    │
 │  │                                                                 │    │
@@ -214,7 +222,7 @@ This command is the second phase of the SPDD workflow:
 │  └────────────────────────────────────────────────────────────────┘    │
 │                              │                                          │
 │                              ▼                                          │
-│  Phase 3: Review & Iteration                                            │
+│  Phase 4: Review & Iteration                                            │
 │  ┌────────────────────────────────────────────────────────────────┐    │
 │  │ Issue Found → Update Prompt → Regenerate → Commit Together     │    │
 │  │                                                                 │    │


### PR DESCRIPTION
## Summary

Fixes #11. The `spdd-generate` template referenced a `/spdd-context` command that no longer exists — it was split into `/spdd-analysis` and `/spdd-reasons-canvas`. Because these templates generate into user projects, the stale reference propagated to end users' `.claude/commands/` and `.cursor/commands/` files.

## Changes

Updated the "Integration" section and workflow diagram in both:
- `internal/templates/data/core/spdd-generate.md`
- `.cursor/commands/spdd-generate.md`

Workflow now reflects the current phases:
1. `/spdd-analysis` — requirement → enriched strategic context
2. `/spdd-reasons-canvas` — context → REASONS Canvas structured prompt
3. `/spdd-generate` — structured prompt → code
4. Review & Iteration

No remaining `spdd-context` references (`grep` verified).