### PR TITLE
Add SPDD Explore Mode, update Antigravity workflows path, and standar…

### DIFF
--- a/.cursor/commands/spdd-explore.md
+++ b/.cursor/commands/spdd-explore.md
@@ -1,0 +1,118 @@
+---
+name: spdd-explore
+id: spdd-explore
+category: Development
+description: Enters explore mode — a thinking partner for exploring ideas, investigating problems, and clarifying requirements before starting a formal analysis.
+---
+
+## Default Deny Policy
+
+Every action must be validated against these rules before execution. If in doubt, **deny**.
+
+### Fundamental Guardrails
+
+1. **Absolute Read-Only**: You MAY read, browse, and map the codebase. You must **NEVER** modify, create, or delete project files (except Explore Decision Log drafts as described in the Decision Log section).
+2. **Zero Code**: Explore mode is dedicated to ideation, investigation, and clarification. You must **NEVER** write implementable code. If the user requests implementation, redirect them: *"To implement this, exit explore mode and use `/spdd-generate` (or run `/spdd-analysis` first)."*
+3. **No Rigid Workflow**: This is a *stance*, not an algorithm. Do not require mandatory templates or force the creation of unnecessary files.
+4. **SPDD Alignment**: The secondary objective is to mature the requirements until they are ready for `/spdd-analysis`.
+
+### Exception Handlers (Anti-Fragility)
+
+- **IF** the provided context is extremely shallow or vague: **DO NOT** attempt to guess the architecture. **PAUSE** the process and begin validation questioning until the scenario becomes viable.
+- **IF** the user insists on breaking the read-only rules after the first warning: **FORMALLY TERMINATE** the exploration, warn about the scope violation, and refuse to continue until the approach changes.
+- **IF** the user attempts to force code generation after being redirected: **DO NOT give in**. Reiterate that implementation requires switching commands.
+- **IF** the user attempts to force a transition to `/spdd-analysis` before the criteria are met: **DO NOT** suggest the transition. Explain which gaps still need to be resolved.
+
+---
+
+## Core (The "Why")
+
+The main objective is to act as a **pre-analysis and ideation phase**.
+
+- **Mindset**: Curious, not prescriptive. Ask questions that naturally emerge from the context.
+- **Open paths, don't interrogate**: Present multiple directions and let the user choose what resonates most.
+- **Visual**: Use diagrams (Mermaid or ASCII), trade-off tables, and data flows extensively.
+- **Patient**: Do not jump to conclusions. Let the shape of the problem emerge.
+- **Grounded**: Map and explore the current code before proposing abstract solutions.
+
+---
+
+## Distorted Mirror Technique
+
+Every 3–4 interactions, **REFLECT** your current understanding of the problem, BUT **DELIBERATELY INJECT** 1–2 reasonable yet UNCONFIRMED assumptions into your summary.
+
+**Example**:
+
+- User describes: *"I need to improve the login"*
+- Distorted Mirror: *"So you want to implement OAuth2 with refresh tokens stored in Redis while maintaining compatibility with existing sessions..."*
+- Revealed correction: *"Actually, we use stateless JWTs and Redis is only for rate limiting."*
+
+**Rules**:
+
+1. The distortions must be **plausible** (not absurd).
+2. Mark them subtly — do not announce that you are testing.
+3. The goal is to **reveal what the user assumes you already know**.
+4. Never use this to confirm complex architectures — only to expose hidden assumptions.
+
+This technique replaces the generic question *"Are there any implicit assumptions?"* with an active prompt that encourages the user to make tacit knowledge explicit.
+
+---
+
+## Micro Action Segments
+
+Execute on demand based on the user's input.
+
+### M1: Explore the Problem Space
+
+- Constructively challenge the user's assumptions.
+- Reframe the problem to reveal hidden complexities or possible simplifications.
+- Look for analogies in the current system or common industry patterns.
+
+### M2: Investigate the Codebase
+
+- Browse the files and map the architecture relevant to the current discussion.
+- Identify existing reusable patterns.
+- Highlight bottlenecks, integration blind spots, and emerging technical debt.
+
+### M3: Compare Options
+
+- Generate a trade-off matrix (Pros/Cons/Risks) for **no more than 3** viable approaches.
+- Analyze the dimensions of Performance, Maintainability, and Scalability.
+- Sketch preliminary architectures only for the most viable options.
+
+### M4: Expose Risks and Uncertainties
+
+- Map "Unknown Unknowns" (what we don't know that we don't know).
+- Identify edge cases early.
+- Suggest proof-of-concept spikes if the uncertainty is critical.
+
+---
+
+## Transition Checkpoint
+
+The transition to `/spdd-analysis` should **ONLY** be suggested when **ALL** of the following conditions are true:
+
+- [ ] `problem_defined = TRUE` — The problem has a clear and well-defined scope.
+- [ ] `direction_chosen = TRUE` — There is consensus on an approach among the explored options.
+- [ ] `uncertainties_mitigated = TRUE` — Critical risks have been identified and addressed.
+- [ ] `codebase_mapped = TRUE` — The relevant architecture has been investigated.
+- [ ] `distorted_mirror_applied = TRUE` — The technique has been used at least once to validate technical assumptions.
+- [ ] `implicit_assumptions = FALSE` — No unvalidated assumptions remain.
+
+When all conditions are met, ask: *"This looks very solid now. Would you like me to formalize everything by running `/spdd-analysis` so we can create our foundational strategic artifact?"*
+
+---
+
+## Decision Log
+
+When consensus or a decision is reached during exploration:
+
+- **Create** a draft Markdown document at `spdd/explore/{timestamp}-[Explore]-{description}.md`
+
+This Decision Log path is the **only** authorized write surface during Explore Mode.
+
+---
+
+## Final Reminder
+
+Do not rush the discovery process. Complete clarity about the problem, achieved through conversation—and strategic assumption testing—is often the most valuable deliverable. Explore mode ends when the user feels they have the necessary insights to move forward.

--- a/README.md
+++ b/README.md
@@ -263,10 +263,12 @@ openspdd --tool codex <command>
 | -------------- | ------------------------------------------------------------- | -------------------------- |
 | Cursor         | `.cursor/`, `.cursorrules`                                    | `.cursor/commands/`        |
 | Claude Code    | `.claude/`, `CLAUDE.md`                                       | `.claude/commands/`        |
-| Antigravity    | `.antigravity/`                                               | `.antigravity/commands/`   |
+| Antigravity    | `.antigravity/`                                               | `.agents/workflows/`       |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/copilot-prompts/` | `.github/copilot-prompts/` |
 | OpenCode       | `.opencode/`, `opencode.json`                                 | `.opencode/commands/`      |
 | Codex          | `.codex/`, `.codex/config.toml`                               | `.agents/skills/`          |
+
+**Antigravity migration**: after upgrading, regenerate Antigravity workflows (`openspdd --tool antigravity generate --all`). Files previously written under `.antigravity/commands/` are not moved automatically.
 
 OpenCode command naming follows the markdown filename (for example, `spdd-analysis.md` maps to `/spdd-analysis`). To avoid command alias conflicts in OpenCode, generated OpenCode command files intentionally omit frontmatter `name`.
 
@@ -311,6 +313,7 @@ The following commands are available as beta — not installed by default, but c
 
 | Command            | Description                                                                           |
 | ------------------ | ------------------------------------------------------------------------------------- |
+| `spdd-explore`     | Read-only explore mode to clarify ideas and assumptions before `/spdd-analysis`       |
 | `spdd-story`       | Decompose feature requirements into INVEST-compliant stories with acceptance criteria |
 | `spdd-code-review` | Review code against REASONS-Canvas, detecting intent drift and violations             |
 | `spdd-api-test`    | Generate self-contained shell scripts with cURL commands for API testing              |
@@ -321,6 +324,7 @@ The following commands are available as beta — not installed by default, but c
 openspdd list --optional
 
 # Install a specific optional command
+openspdd generate spdd-explore
 openspdd generate spdd-story
 openspdd generate spdd-code-review
 openspdd generate spdd-api-test

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -271,10 +271,12 @@ openspdd --tool codex <command>
 | -------------- | ------------------------------------------------------------- | -------------------------- |
 | Cursor         | `.cursor/`, `.cursorrules`                                    | `.cursor/commands/`        |
 | Claude Code    | `.claude/`, `CLAUDE.md`                                       | `.claude/commands/`        |
-| Antigravity    | `.antigravity/`                                               | `.antigravity/commands/`   |
+| Antigravity    | `.antigravity/`                                               | `.agents/workflows/`       |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/copilot-prompts/` | `.github/copilot-prompts/` |
 | OpenCode       | `.opencode/`, `opencode.json`                                 | `.opencode/commands/`      |
 | Codex          | `.codex/`, `.codex/config.toml`                               | `.agents/skills/`          |
+
+**Antigravity 迁移说明**：升级后请重新生成 Antigravity workflows（`openspdd --tool antigravity generate --all`）。此前写入 `.antigravity/commands/` 的文件不会自动迁移。
 
 OpenCode 的命令名由 Markdown 文件名决定（例如 `spdd-analysis.md` 对应 `/spdd-analysis`）。为避免 OpenCode 中的命令别名冲突，生成到 OpenCode 的命令文件会有意省略 frontmatter `name` 字段。
 
@@ -319,6 +321,7 @@ Codex 会以项目级 skill 包的形式生成命令模板，输出到 `.agents/
 
 | 命令               | 描述                                                 |
 | ------------------ | ---------------------------------------------------- |
+| `spdd-explore`     | 只读探索模式，在进入 `/spdd-analysis` 前澄清想法与隐含假设 |
 | `spdd-story`       | 将功能需求拆解为符合 INVEST 原则的 Story，含验收标准 |
 | `spdd-code-review` | 对照 REASONS-Canvas 审查代码，检测意图偏移与约束违规 |
 | `spdd-api-test`    | 生成基于 cURL 的自包含 API 测试脚本                  |
@@ -329,6 +332,7 @@ Codex 会以项目级 skill 包的形式生成命令模板，输出到 `.agents/
 openspdd list --optional
 
 # 安装特定可选命令
+openspdd generate spdd-explore
 openspdd generate spdd-story
 openspdd generate spdd-code-review
 openspdd generate spdd-api-test

--- a/internal/detector/types.go
+++ b/internal/detector/types.go
@@ -41,7 +41,7 @@ func (t AIToolType) GetConfigDir() string {
 	case ClaudeCode:
 		return ".claude/commands"
 	case Antigravity:
-		return ".antigravity/commands"
+		return ".agents/workflows"
 	case GitHubCopilot:
 		return ".github/copilot-prompts"
 	case OpenCode:

--- a/internal/templates/data/core/spdd-analysis.md
+++ b/internal/templates/data/core/spdd-analysis.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-analysis
+name: spdd-analysis
 id: spdd-analysis
 category: Development
 description: Analyze business requirements against codebase context at a strategic level, producing enriched context (business + domain concepts + strategic direction + risks) for REASONS Canvas generation

--- a/internal/templates/data/core/spdd-generate.md
+++ b/internal/templates/data/core/spdd-generate.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-generate
+name: spdd-generate
 id: spdd-generate
 category: Development
 description: Generate code from a structured SPDD prompt file following the REASONS Canvas methodology

--- a/internal/templates/data/core/spdd-prompt-update.md
+++ b/internal/templates/data/core/spdd-prompt-update.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-prompt-update
+name: spdd-prompt-update
 id: spdd-prompt-update
 category: Development
 description: Update an existing SPDD prompt file with new requirements or architectural changes while preserving the REASONS Canvas structure

--- a/internal/templates/data/core/spdd-reasons-canvas.md
+++ b/internal/templates/data/core/spdd-reasons-canvas.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-reasons-canvas
+name: spdd-reasons-canvas
 id: spdd-reasons-canvas
 category: Development
 description: Generate REASONS-Canvas structured prompts from business context without external template

--- a/internal/templates/data/core/spdd-sync.md
+++ b/internal/templates/data/core/spdd-sync.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-sync
+name: spdd-sync
 id: spdd-sync
 category: Development
 description: Sync code changes back to the structured SPDD prompt file following the REASONS Canvas methodology

--- a/internal/templates/data/optional/aupro-context.md
+++ b/internal/templates/data/optional/aupro-context.md
@@ -1,5 +1,5 @@
 ---
-name: /aupro-context
+name: aupro-context
 id: aupro-context
 category: Development
 description: Generate structured development context from a requirement using Aupro, save to file, then implement

--- a/internal/templates/data/optional/spdd-api-test.md
+++ b/internal/templates/data/optional/spdd-api-test.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-api-test
+name: spdd-api-test
 id: spdd-api-test
 category: Testing
 description: Generate a self-contained shell script with cURL commands to test API endpoints based on generated code and acceptance criteria

--- a/internal/templates/data/optional/spdd-code-review.md
+++ b/internal/templates/data/optional/spdd-code-review.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-code-review
+name: spdd-code-review
 id: spdd-code-review
 category: Development
 description: Review AI-generated code against REASONS-Canvas structured prompts, detecting intent drift, safeguard violations, and scope boundary issues to reduce human reviewer cognitive load

--- a/internal/templates/data/optional/spdd-explore.md
+++ b/internal/templates/data/optional/spdd-explore.md
@@ -1,0 +1,118 @@
+---
+name: spdd-explore
+id: spdd-explore
+category: Development
+description: Enters explore mode — a thinking partner for exploring ideas, investigating problems, and clarifying requirements before starting a formal analysis.
+---
+
+## Default Deny Policy
+
+Every action must be validated against these rules before execution. If in doubt, **deny**.
+
+### Fundamental Guardrails
+
+1. **Absolute Read-Only**: You MAY read, browse, and map the codebase. You must **NEVER** modify, create, or delete project files (except Explore Decision Log drafts as described in the Decision Log section).
+2. **Zero Code**: Explore mode is dedicated to ideation, investigation, and clarification. You must **NEVER** write implementable code. If the user requests implementation, redirect them: *"To implement this, exit explore mode and use `/spdd-generate` (or run `/spdd-analysis` first)."*
+3. **No Rigid Workflow**: This is a *stance*, not an algorithm. Do not require mandatory templates or force the creation of unnecessary files.
+4. **SPDD Alignment**: The secondary objective is to mature the requirements until they are ready for `/spdd-analysis`.
+
+### Exception Handlers (Anti-Fragility)
+
+- **IF** the provided context is extremely shallow or vague: **DO NOT** attempt to guess the architecture. **PAUSE** the process and begin validation questioning until the scenario becomes viable.
+- **IF** the user insists on breaking the read-only rules after the first warning: **FORMALLY TERMINATE** the exploration, warn about the scope violation, and refuse to continue until the approach changes.
+- **IF** the user attempts to force code generation after being redirected: **DO NOT give in**. Reiterate that implementation requires switching commands.
+- **IF** the user attempts to force a transition to `/spdd-analysis` before the criteria are met: **DO NOT** suggest the transition. Explain which gaps still need to be resolved.
+
+---
+
+## Core (The "Why")
+
+The main objective is to act as a **pre-analysis and ideation phase**.
+
+- **Mindset**: Curious, not prescriptive. Ask questions that naturally emerge from the context.
+- **Open paths, don't interrogate**: Present multiple directions and let the user choose what resonates most.
+- **Visual**: Use diagrams (Mermaid or ASCII), trade-off tables, and data flows extensively.
+- **Patient**: Do not jump to conclusions. Let the shape of the problem emerge.
+- **Grounded**: Map and explore the current code before proposing abstract solutions.
+
+---
+
+## Distorted Mirror Technique
+
+Every 3–4 interactions, **REFLECT** your current understanding of the problem, BUT **DELIBERATELY INJECT** 1–2 reasonable yet UNCONFIRMED assumptions into your summary.
+
+**Example**:
+
+- User describes: *"I need to improve the login"*
+- Distorted Mirror: *"So you want to implement OAuth2 with refresh tokens stored in Redis while maintaining compatibility with existing sessions..."*
+- Revealed correction: *"Actually, we use stateless JWTs and Redis is only for rate limiting."*
+
+**Rules**:
+
+1. The distortions must be **plausible** (not absurd).
+2. Mark them subtly — do not announce that you are testing.
+3. The goal is to **reveal what the user assumes you already know**.
+4. Never use this to confirm complex architectures — only to expose hidden assumptions.
+
+This technique replaces the generic question *"Are there any implicit assumptions?"* with an active prompt that encourages the user to make tacit knowledge explicit.
+
+---
+
+## Micro Action Segments
+
+Execute on demand based on the user's input.
+
+### M1: Explore the Problem Space
+
+- Constructively challenge the user's assumptions.
+- Reframe the problem to reveal hidden complexities or possible simplifications.
+- Look for analogies in the current system or common industry patterns.
+
+### M2: Investigate the Codebase
+
+- Browse the files and map the architecture relevant to the current discussion.
+- Identify existing reusable patterns.
+- Highlight bottlenecks, integration blind spots, and emerging technical debt.
+
+### M3: Compare Options
+
+- Generate a trade-off matrix (Pros/Cons/Risks) for **no more than 3** viable approaches.
+- Analyze the dimensions of Performance, Maintainability, and Scalability.
+- Sketch preliminary architectures only for the most viable options.
+
+### M4: Expose Risks and Uncertainties
+
+- Map "Unknown Unknowns" (what we don't know that we don't know).
+- Identify edge cases early.
+- Suggest proof-of-concept spikes if the uncertainty is critical.
+
+---
+
+## Transition Checkpoint
+
+The transition to `/spdd-analysis` should **ONLY** be suggested when **ALL** of the following conditions are true:
+
+- [ ] `problem_defined = TRUE` — The problem has a clear and well-defined scope.
+- [ ] `direction_chosen = TRUE` — There is consensus on an approach among the explored options.
+- [ ] `uncertainties_mitigated = TRUE` — Critical risks have been identified and addressed.
+- [ ] `codebase_mapped = TRUE` — The relevant architecture has been investigated.
+- [ ] `distorted_mirror_applied = TRUE` — The technique has been used at least once to validate technical assumptions.
+- [ ] `implicit_assumptions = FALSE` — No unvalidated assumptions remain.
+
+When all conditions are met, ask: *"This looks very solid now. Would you like me to formalize everything by running `/spdd-analysis` so we can create our foundational strategic artifact?"*
+
+---
+
+## Decision Log
+
+When consensus or a decision is reached during exploration:
+
+- **Create** a draft Markdown document at `spdd/explore/{timestamp}-[Explore]-{description}.md`
+
+This Decision Log path is the **only** authorized write surface during Explore Mode.
+
+---
+
+## Final Reminder
+
+Do not rush the discovery process. Complete clarity about the problem, achieved through conversation—and strategic assumption testing—is often the most valuable deliverable. Explore mode ends when the user feels they have the necessary insights to move forward.

--- a/internal/templates/data/optional/spdd-reverse.md
+++ b/internal/templates/data/optional/spdd-reverse.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-reverse
+name: spdd-reverse
 id: spdd-reverse
 category: Development
 description: Reverse-engineer existing code into a REASONS-Canvas structured prompt, enabling the SPDD bidirectional sync workflow for previously unspecified implementations

--- a/internal/templates/data/optional/spdd-story.md
+++ b/internal/templates/data/optional/spdd-story.md
@@ -1,5 +1,5 @@
 ---
-name: /spdd-story
+name: spdd-story
 id: spdd-story
 category: Development
 description: Decompose high-level feature requirements into INVEST-compliant, business-focused stories with clear scope boundaries and testable acceptance criteria

--- a/internal/templates/manager.go
+++ b/internal/templates/manager.go
@@ -160,6 +160,8 @@ func (m *EmbeddedTemplateManager) ListAll() ([]TemplateMeta, error) {
 }
 
 // GetByName returns a template by its name (case-insensitive).
+// A single leading "/" is trimmed for compatibility with slash-prefixed lookups
+// (e.g. "/spdd-analysis" matches name/id "spdd-analysis").
 func (m *EmbeddedTemplateManager) GetByName(name string) (TemplateMeta, error) {
 	templates, err := m.ListAll()
 	if err != nil {
@@ -167,8 +169,11 @@ func (m *EmbeddedTemplateManager) GetByName(name string) (TemplateMeta, error) {
 	}
 
 	nameLower := strings.ToLower(name)
+	normalized := strings.TrimPrefix(nameLower, "/")
 	for _, t := range templates {
-		if strings.ToLower(t.Name) == nameLower || strings.ToLower(t.ID) == nameLower {
+		tName := strings.ToLower(t.Name)
+		tID := strings.ToLower(t.ID)
+		if tName == nameLower || tID == nameLower || tName == normalized || tID == normalized {
 			return t, nil
 		}
 	}

--- a/spdd/analysis/GGQPA-007-202607231330-[Analysis]-spdd-explore-mode-and-template-standardization.md
+++ b/spdd/analysis/GGQPA-007-202607231330-[Analysis]-spdd-explore-mode-and-template-standardization.md
@@ -1,0 +1,127 @@
+# SPDD Analysis: Add SPDD Explore Mode and Standardize Template Metadata
+
+## Original Business Requirement
+
+New Explore Mode Workflow:
+
+Create spdd-explore.md to establish a safe, read-only thinking phase ("Explore Mode") for AI coding assistants.
+Enforce an absolute read-only policy, prohibiting code generation or file mutation in this mode.
+Embed the "Distorted Mirror Technique" to surface user assumptions and validate initial scopes.
+Design micro action segments (M1-M4) and clear transition criteria before initiating /spdd-analysis.
+
+Configuration & Paths Alignment:
+
+Update Antigravity configuration directory path mapping to .agents/workflows in internal/detector/types.go.
+
+Template Metadata Standardization:
+
+Standardize core Markdown templates (spdd-analysis, spdd-generate, spdd-prompt-update, spdd-reasons-canvas, spdd-sync) by stripping the leading slash (/) from their frontmatter name fields.
+
+Follow-up refinement (same initiative):
+
+refactor: move spdd-explore template to optional and remove '/' prefix from optional template names
+
+- Move `internal/templates/data/core/spdd-explore.md` → `internal/templates/data/optional/spdd-explore.md`
+- Strip leading `/` from optional template frontmatter `name` fields (`aupro-context`, `spdd-api-test`, `spdd-code-review`, `spdd-reverse`, `spdd-story`)
+
+Associated design intent already captured in PR prompt draft:
+
+1. **New Explore Mode Workflow**:
+   - Create `spdd-explore.md` to establish a safe, read-only thinking phase ("Explore Mode") for AI coding assistants.
+   - Enforce an absolute read-only policy, prohibiting code generation or file mutation in this mode.
+   - Embed the "Distorted Mirror Technique" to surface user assumptions and validate initial scopes.
+   - Design micro action segments (M1-M4) and clear transition criteria before initiating `/spdd-analysis`.
+
+2. **Configuration & Paths Alignment**:
+   - Update `Antigravity` configuration directory path mapping to `.agents/workflows` in `internal/detector/types.go`.
+
+3. **Template Metadata Standardization**:
+   - Standardize core Markdown templates (`spdd-analysis`, `spdd-generate`, `spdd-prompt-update`, `spdd-reasons-canvas`, `spdd-sync`) by stripping the leading slash (`/`) from their frontmatter `name` fields.
+
+## Domain Concept Identification
+
+### Existing Concepts (from codebase)
+- `AIToolType` + `GetConfigDir()`: closed enum of supported assistants; Antigravity currently maps to `.antigravity/commands`, while Codex already owns `.agents/skills` under the shared `.agents/` parent namespace.
+- `EmbeddedTemplateManager` + hierarchical template corpus: `data/core/` (default install), `data/optional/` (opt-in via `list --optional` / explicit generate), `data/tools/<tool>/` (tool-specific assets).
+- Core SPDD workflow commands: `spdd-analysis`, `spdd-reasons-canvas`, `spdd-generate`, `spdd-prompt-update`, `spdd-sync` — currently shipped with frontmatter `name: /spdd-*`.
+- Optional pre/post pipeline commands: `spdd-story`, `spdd-api-test`, `spdd-code-review`, `spdd-reverse`, `aupro-context` — also currently `name: /...`.
+- `TemplateMeta.Name` / `GetByName`: lookup accepts either `Name` or `ID` (case-insensitive); many tests and Codex/OpenCode flows still call `GetByName("/spdd-analysis")`.
+- `OpenCodeTemplateAdapter`: generation-time strip of the `name` frontmatter key for OpenCode only (implements GGQPA-006 strategy-local adaptation).
+- `CodexSkillStrategy`: strips leading `/` from `Name` when emitting skill `name:` for Codex SKILL.md.
+- Flat generation strategies for Cursor / Claude Code / Antigravity / OpenCode: write `<configDir>/<id>.md` using filename-as-command identity for most tools.
+- Existing SPDD analysis GGQPA-006: previously rejected globally rewriting core templates to remove slash-prefixed `name`, favoring OpenCode-specific output adaptation instead.
+
+### New Concepts Required
+- `Explore Mode (spdd-explore)`: optional, read-mostly pre-analysis stance that matures ambiguous requirements before `/spdd-analysis`; includes Distorted Mirror Technique, micro-segments M1–M4, and transition checkpoint gates.
+- `Explore Decision Log artifact`: draft markdown records under `spdd/explore/{timestamp}-[Explore]-{description}.md` as the only intended write surface during exploration.
+- `Slash-free template name convention`: frontmatter `name` values without leading `/` across core and optional templates, while slash invocation remains a UI/runtime concern of each assistant.
+- `Antigravity workflows path`: config target `.agents/workflows` instead of `.antigravity/commands`, aligning Antigravity install layout with Antigravity’s expected workflows directory.
+
+### Key Business Rules
+- Explore mode is opt-in (optional template), not part of default `generate --all` core install.
+- Explore mode must not implement product code; it may only produce explore decision-log drafts under `spdd/explore/`.
+- Transition to `/spdd-analysis` is suggested only when problem scope, chosen direction, mitigated uncertainties, codebase mapping, distorted-mirror validation, and cleared implicit assumptions are all satisfied.
+- Template identity for generation remains `id` / filename (`spdd-explore.md` → command `spdd-explore`); frontmatter `name` is metadata for listing/lookup, not the sole command identity.
+- Antigravity generation must land under `.agents/workflows` after the path change.
+- Changing source frontmatter `name` values must not break `GetByName` for users/tests that still pass slash-prefixed names (ID fallback already supports `spdd-*` without slash; slash-prefixed Name lookups need an explicit compatibility decision).
+- OpenCode’s existing strip-`name` adapter and Codex’s slash-trim logic must remain correct after source metadata standardization.
+
+## Strategic Approach
+
+### Solution Direction
+- Treat this as three coordinated, low-code product changes inside the existing openspdd CLI corpus: (1) add an optional explore-mode command template that slots before analysis in the SPDD mental model, (2) realign Antigravity’s install path via `AIToolType.GetConfigDir()`, and (3) normalize frontmatter `name` fields to slash-free values across core and optional templates, updating tests/docs that assert the old slash-prefixed convention.
+- Prefer extending the existing template hierarchy and detector mapping rather than introducing new packages, generation strategies, or workflow engines.
+
+### Key Design Decisions
+- `Explore placement = optional, not core`: keeps default installs lean and matches “stance/pre-analysis” nature; users who want discovery opt in via optional listing/generation → recommendation: keep optional (as in the follow-up commit).
+- `Explore writes decision logs only`: absolute read-only for product code, with an explicit exception for `spdd/explore/*.md` drafts → recommendation: document the exception as the sole mutation surface to avoid policy contradiction.
+- `Antigravity path → `.agents/workflows``: aligns with Antigravity workflow conventions, but shares the `.agents/` parent with Codex’s `.agents/skills` → recommendation: proceed with path change, and explicitly verify uninstall/init/detection do not assume exclusive ownership of `.agents/`.
+- `Slash removal in source templates`: simplifies cross-tool metadata and matches Codex’s already-trimmed skill names; conflicts with GGQPA-006’s earlier preference to avoid global source edits → recommendation: accept the standardization only if lookup compatibility is preserved (ID match and/or slash-tolerant `GetByName`) and OpenCode/Codex adapters are revalidated.
+- `No new Go runtime behavior for Explore Mode`: explore is prompt/policy content consumed by AI assistants after generation; openspdd’s job is to ship and install the markdown template correctly.
+
+### Alternatives Considered
+- `Ship Explore Mode as a core template`: rejected for default-install bloat and because explore is situational rather than mandatory pipeline step.
+- `Keep Antigravity at `.antigravity/commands``: rejected by the requirement’s path-alignment goal; would leave Antigravity installs misaligned with expected workflows directory.
+- `Only adapt slash at generation time (status quo from GGQPA-006)`: rejected for this initiative’s standardization goal, but remains a safety net for OpenCode; source slash removal and OpenCode strip-`name` can coexist.
+- `Hard-enforce explore transition gates in CLI code`: rejected as out of scope — gates belong in the command prompt behavior, not in openspdd’s Go runtime.
+
+## Risk & Gap Analysis
+
+### Requirement Ambiguities
+- `Read-only vs Decision Log contradiction`: “absolute read-only / never create project files” coexists with creating `spdd/explore/...` drafts — needs a single authoritative exception statement.
+- `Antigravity signature vs config path divergence`: detection still keys on `.antigravity` signatures while config writes move to `.agents/workflows`; unclear whether detection/signature set should also expand to `.agents/workflows`.
+- `Slash-prefixed lookup compatibility`: requirement strips `name: /spdd-*` to `name: spdd-*` but does not say whether `openspdd generate /spdd-analysis` (or tests using `GetByName("/spdd-analysis")`) must keep working.
+- `Relationship to GGQPA-006`: earlier analysis rejected global slash removal; this initiative reverses that product decision without stating whether GGQPA-006’s OpenCode adapter remains necessary (it still is, because OpenCode should not emit `name` at all).
+- `Explore artifact lifecycle`: no AC for when explore drafts are required, optional, overwritten, or promoted into `spdd/analysis/`.
+- `Distorted Mirror ethics/UX`: technique deliberately injects unconfirmed assumptions without announcing the test — acceptable for power users, but may confuse newcomers; no guidance on frequency/safety boundaries beyond “every 3–4 interactions”.
+
+### Edge Cases
+- `Multi-tool repos with both Codex and Antigravity`: both use `.agents/...` children; init/uninstall must not delete sibling tool content.
+- `Users with previously generated Antigravity files under `.antigravity/commands``: path change leaves stale commands unless migration/regeneration guidance exists.
+- `Optional explore not installed`: users invoking `/spdd-explore` in an assistant that never received the optional template will fail; docs must clarify opt-in install.
+- `Explore Decision Log vs analysis naming`: similar timestamped markdown patterns under `spdd/explore` vs `spdd/analysis` may confuse consumers of SPDD artifacts.
+- `Tests asserting `name: /spdd-*` or `GetByName("/...")`**: will fail or become misleading after frontmatter standardization unless updated or made slash-tolerant.
+- `Cursor/Claude installed copies in user projects`: regenerating templates updates target dirs; local `.cursor/commands` copies in this repo currently still carry slash-prefixed names and are out-of-band relative to embedded sources.
+
+### Technical Risks
+- `Regression in template lookup UX`: if `Name` loses the leading `/` and callers still pass `/spdd-*`, only ID match saves them when the argument equals `spdd-*` without slash; `/spdd-analysis` would no longer match `Name` and does not equal `ID` → mitigation: teach `GetByName` to trim a single leading `/` before comparison, or update all call sites/tests.
+- `Antigravity uninstall/init blast radius under `.agents/``: shared parent with Codex skills increases accidental cleanup risk → mitigation: scope file operations strictly to `.agents/workflows`, never the entire `.agents` tree.
+- `OpenCode/Codex adapter drift`: source `name` without slash changes assumptions in tests that assert presence/absence of specific frontmatter strings → mitigation: re-run OpenCode flat-strategy and Codex skill-strategy suites as required gates.
+- `Detector still points at `.antigravity` while outputs go to `.agents/workflows``: projects without `.antigravity` marker but with workflows dir may not auto-detect Antigravity → mitigation: clarify whether signature files should include `.agents/workflows`.
+- `Policy enforcement is soft`: explore read-only rules live in prompt text only; assistants can still violate them → mitigation: accept soft enforcement (consistent with other SPDD commands) and keep optional placement.
+
+### Acceptance Criteria Coverage
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 1 | Add `spdd-explore` command template establishing Explore Mode (read-mostly thinking partner before analysis) | Yes | Content is prompt-level; no Go runtime needed beyond embedding/listing. |
+| 2 | Explore Mode prohibits implementable code generation and product-file mutation | Partial | Soft prompt policy only; Decision Log write exception must be clarified. |
+| 3 | Distorted Mirror Technique is embedded with rules and example | Yes | Prompt content; no automated verification possible in openspdd CLI. |
+| 4 | Micro action segments M1–M4 and transition checkpoint to `/spdd-analysis` are defined | Yes | Prompt content; transition gates are conversational, not machine-checked. |
+| 5 | `spdd-explore` is available as an optional (not default/core) template | Yes | Follow-up already places it under `data/optional/`; `ListAvailable`/`generate --all` will not include it by default. |
+| 6 | Antigravity `GetConfigDir()` returns `.agents/workflows` | Yes | One-line detector mapping + test expectation update. |
+| 7 | Core templates’ frontmatter `name` values have no leading `/` | Yes | Edit five core markdown sources; update dependent assertions. |
+| 8 | Optional templates’ frontmatter `name` values have no leading `/` | Yes | Includes explore + existing optional set. |
+| 9 | Existing tool generation for non-Antigravity tools remains functionally correct | Partial | Requires regression tests; slash-removal can break slash-prefixed `GetByName` callers. |
+| 10 | OpenCode continues to avoid emitting conflicting `name` identity in generated commands | Yes | Existing `OpenCodeTemplateAdapter` still strips `name`; should remain. |
+| 11 | Codex skill naming remains slash-free and stable | Yes | `TrimPrefix(meta.Name, "/")` stays valid whether source has slash or not. |
+| 12 | Users with stale `.antigravity/commands` artifacts are guided to regenerate under `.agents/workflows` | Partial | Not stated in requirement; recommended docs/migration note. |

--- a/spdd/prompt/GGQPA-007-202607231332-[Feat]-templates-spdd-explore-and-standardization.md
+++ b/spdd/prompt/GGQPA-007-202607231332-[Feat]-templates-spdd-explore-and-standardization.md
@@ -1,0 +1,331 @@
+# Add SPDD Explore Mode, Antigravity Workflows Path, and Slash-Free Template Names
+
+## Requirements
+- Deliver an optional Explore Mode command that helps users clarify ambiguous problems before formal SPDD analysis, without generating product code.
+- Align Antigravity template installation with the `.agents/workflows` directory convention while preserving detection via the existing Antigravity project marker.
+- Standardize embedded core and optional template frontmatter so `name` values are slash-free, while keeping slash-prefixed CLI lookups working for compatibility.
+- Preserve existing OpenCode name-stripping and Codex skill naming behavior after metadata standardization.
+
+## Entities
+```mermaid
+classDiagram
+direction TB
+
+class AIToolType {
+    +Cursor
+    +ClaudeCode
+    +Antigravity
+    +GitHubCopilot
+    +OpenCode
+    +Codex
+    +Unknown
+    +GetConfigDir() string
+    +GetSignatureFiles() []string
+    +GetToolDirName() string
+}
+
+class TemplateMeta {
+    +string Name
+    +string ID
+    +string Category
+    +string Description
+    +string Content
+}
+
+class EmbeddedTemplateManager {
+    +ListCore() []TemplateMeta
+    +ListOptional() []TemplateMeta
+    +ListAvailable(AIToolType) []TemplateMeta
+    +ListAll() []TemplateMeta
+    +GetByName(string name) TemplateMeta
+    +Generate(GenerateRequest) GenerateResult
+}
+
+class FlatMarkdownStrategy {
+    +AIToolType tool
+    +GenerateAll(string, bool) []GenerateResult
+    +GenerateOne(string, TemplateMeta, bool) []GenerateResult
+}
+
+class OpenCodeTemplateAdapter {
+    +IsApplicable(AIToolType) bool
+    +NormalizeForOpenCode(TemplateMeta) string
+    +StripFrontmatterName(string) string
+}
+
+class CodexSkillStrategy {
+    +GenerateAll(string, bool) []GenerateResult
+    +GenerateOne(string, TemplateMeta, bool) []GenerateResult
+}
+
+class ExploreCommandTemplate {
+    +string id
+    +string name
+    +string category
+    +string description
+    +string body
+}
+
+class ExploreDecisionLog {
+    +string pathPattern
+    +string purpose
+}
+
+AIToolType --> FlatMarkdownStrategy : config dir drives output path
+EmbeddedTemplateManager --> TemplateMeta : loads embedded markdown
+EmbeddedTemplateManager --> ExploreCommandTemplate : optional corpus includes explore
+FlatMarkdownStrategy --> EmbeddedTemplateManager : writes files
+FlatMarkdownStrategy --> OpenCodeTemplateAdapter : OpenCode-only normalize
+CodexSkillStrategy --> EmbeddedTemplateManager : skill bundle output
+ExploreCommandTemplate --> ExploreDecisionLog : authorizes draft writes
+```
+
+## Approach
+1. Template Corpus Extension:
+   - Add `spdd-explore` as an optional embedded markdown command under `internal/templates/data/optional/`.
+   - Do not place explore in `data/core/`, so `ListAvailable` and default `generate --all` remain unchanged.
+   - Encode Explore Mode as prompt policy (Default Deny, Distorted Mirror, M1–M4, transition checkpoint, Decision Log), not as new Go workflow runtime.
+
+2. Detector Path Alignment:
+   - Change only `Antigravity.GetConfigDir()` to return `.agents/workflows`.
+   - Keep `GetSignatureFiles()` for Antigravity as `.antigravity` so auto-detection behavior remains stable.
+   - Rely on existing `filepath.Join(workingDir, GetConfigDir())` consumers (init/generate/uninstall) so Antigravity writes and cleanup target `.agents/workflows` exclusively, never the whole `.agents` tree (Codex owns `.agents/skills`).
+
+3. Frontmatter Standardization + Lookup Compatibility:
+   - Update every core and optional template frontmatter `name` from `/...` to the bare command id-style value (example: `spdd-analysis`, `spdd-explore`).
+   - Keep `id` fields unchanged.
+   - Teach `GetByName` to normalize the lookup key by trimming a single leading `/` before case-insensitive comparison against `Name` and `ID`, so both `spdd-analysis` and `/spdd-analysis` resolve.
+   - Leave `OpenCodeTemplateAdapter` in place: OpenCode outputs must still omit the `name` key entirely.
+   - Leave Codex `TrimPrefix(meta.Name, "/")` behavior in place; with slash-free source names it becomes a no-op trim and remains correct.
+
+4. Documentation and Regression Gates:
+   - Update README tables that still advertise Antigravity commands under `.antigravity/commands/` to `.agents/workflows/`.
+   - Add a short migration note: regenerate Antigravity workflows after upgrade; stale files under `.antigravity/commands/` are not auto-migrated.
+   - Update detector/template tests that hard-code the old Antigravity path or slash-prefixed `name` assertions.
+
+## Structure
+
+### Inheritance Relationships
+1. `AIToolType` remains the closed enum driving config directories and signatures; only the Antigravity config-dir branch changes.
+2. `TemplateManager` interface remains unchanged; `EmbeddedTemplateManager` continues to implement it.
+3. `FlatMarkdownStrategy` and `CodexSkillStrategy` continue to implement the existing generation strategy contract.
+4. `OpenCodeTemplateAdapter` remains a focused compatibility helper used by `FlatMarkdownStrategy` for OpenCode only.
+5. No new exception types or packages are introduced.
+
+### Dependencies
+1. CLI generate/init/uninstall paths depend on `AIToolType.GetConfigDir()` for Antigravity output location.
+2. `EmbeddedTemplateManager.GetByName` depends on slash-tolerant name normalization before matching `TemplateMeta.Name`/`ID`.
+3. `FlatMarkdownStrategy.GenerateOne` depends on `GetConfigDir()` for target directory and on `OpenCodeTemplateAdapter` when tool is OpenCode.
+4. Optional listing (`openspdd list --optional`) depends on `ListOptional()` discovering `spdd-explore.md` via embed.
+5. README EN/ZH documentation depends on accurate Antigravity path rows.
+
+### Layered Architecture
+1. Detector Layer: tool identity, signatures, and config directory mapping.
+2. Template Asset Layer: embedded `data/core` and `data/optional` markdown commands.
+3. Template Management Layer: listing, slash-tolerant lookup, and file writes.
+4. Strategy Layer: tool-specific generation (flat markdown, OpenCode normalize, Codex skills).
+5. CLI/Docs Layer: user-facing install paths, optional template discovery, and migration guidance.
+6. Test Layer: detector path expectations, optional explore presence, frontmatter name contracts, GetByName slash compatibility, OpenCode/Codex regressions.
+
+## Operations
+
+### Update Detector Mapping - `AIToolType.GetConfigDir`
+1. Responsibility: map Antigravity installs to the workflows directory expected by that tool.
+2. Package: `internal/detector`
+3. Methods:
+   - `GetConfigDir()` for `Antigravity`
+     - Logic:
+       - Return exactly `.agents/workflows` (no leading slash, no trailing slash).
+       - Leave all other tool branches unchanged (`Cursor` → `.cursor/commands`, `ClaudeCode` → `.claude/commands`, `GitHubCopilot` → `.github/copilot-prompts`, `OpenCode` → `.opencode/commands`, `Codex` → `.agents/skills`).
+   - `GetSignatureFiles()` for `Antigravity`
+     - Logic:
+       - Keep returning `.antigravity` only in this change set.
+       - Do not add `.agents/workflows` as a detection signature in this feature (avoids false positives with Codex-only `.agents` trees).
+4. Constraints:
+   - Uninstall/init/generate must continue to operate only on the returned config dir, never recursively delete `.agents`.
+5. Verification:
+   - `TestAIToolType_GetConfigDir` Antigravity row expects `.agents/workflows`.
+   - Detector tests that assert Antigravity `ConfigPath` must join working dir with `.agents/workflows`.
+
+### Update Lookup Compatibility - `EmbeddedTemplateManager.GetByName`
+1. Responsibility: keep slash-prefixed and slash-free template lookups working after source `name` standardization.
+2. Package: `internal/templates`
+3. Methods:
+   - `GetByName(name string) (TemplateMeta, error)`
+     - Logic:
+       - Load all templates via existing `ListAll()`.
+       - Normalize the input by lowercasing and trimming a single leading `/` character if present (example: `/spdd-analysis` → `spdd-analysis`).
+       - Also prepare the raw lowercased input for comparison.
+       - Match if either normalized or raw lowercased input equals lowercased `t.Name` or lowercased `t.ID`.
+       - Prefer first match in existing iteration order; return `ErrTemplateNotFound` when none match.
+4. Constraints:
+   - Do not strip more than one leading slash.
+   - Do not alter stored `TemplateMeta.Name` values at parse time; only normalize the lookup key.
+5. Verification:
+   - `GetByName("spdd-analysis")` and `GetByName("/spdd-analysis")` both succeed and return the same `ID`.
+   - Existing case-insensitive tests continue to pass.
+
+### Standardize Core Template Frontmatter Names
+1. Responsibility: remove leading `/` from core command `name` fields.
+2. Files under `internal/templates/data/core/`:
+   - `spdd-analysis.md`
+   - `spdd-generate.md`
+   - `spdd-prompt-update.md`
+   - `spdd-reasons-canvas.md`
+   - `spdd-sync.md`
+3. Logic for each file:
+   - Change frontmatter `name: /<id>` to `name: <id>` where `<id>` equals the existing `id` value.
+   - Keep `id`, `category`, and `description` unchanged.
+   - Do not modify command body content in this operation except where body text is unrelated to this metadata change.
+4. Constraints:
+   - After change, no core template frontmatter line may match `name: /`.
+5. Verification:
+   - `ListCore()` returns `Name` values without leading `/`.
+   - OpenCode generation still strips `name` entirely via adapter.
+   - Non-OpenCode flat generation writes the updated frontmatter verbatim.
+
+### Standardize Optional Template Frontmatter Names
+1. Responsibility: remove leading `/` from optional command `name` fields.
+2. Files under `internal/templates/data/optional/`:
+   - `aupro-context.md`
+   - `spdd-api-test.md`
+   - `spdd-code-review.md`
+   - `spdd-reverse.md`
+   - `spdd-story.md`
+3. Logic for each file:
+   - Change `name: /<id>` to `name: <id>` matching existing `id`.
+   - Keep remaining frontmatter and body intact.
+4. Constraints:
+   - Optional templates remain discoverable only through `ListOptional` / `ListAll`, not through default `ListAvailable`.
+5. Verification:
+   - `ListOptional()` names are slash-free.
+   - Codex optional generate for `spdd-reverse` still produces skill bundle under `.agents/skills/spdd-reverse/`.
+
+### Create Optional Template - `spdd-explore.md`
+1. Responsibility: ship Explore Mode as an opt-in SPDD pre-analysis command template.
+2. Path: `internal/templates/data/optional/spdd-explore.md`
+3. Frontmatter:
+   - `name`: `spdd-explore`
+   - `id`: `spdd-explore`
+   - `category`: `Development`
+   - `description`: `Enters explore mode — a thinking partner for exploring ideas, investigating problems, and clarifying requirements before starting a formal analysis.`
+4. Body sections (must include all of the following, in this order):
+   - `Default Deny Policy` with fundamental guardrails:
+     - Absolute read-only for product code: may read/browse/map codebase; must never modify/create/delete project files except Explore Decision Log drafts.
+     - Zero implementable code: never write implementation code; if user requests implementation, redirect to exit explore and use `/spdd-generate` (or run `/spdd-analysis` first).
+     - No rigid workflow: stance, not mandatory algorithm; do not force unnecessary files.
+     - SPDD alignment: secondary objective is maturing requirements for `/spdd-analysis`.
+   - `Exception Handlers (Anti-Fragility)` covering shallow/vague context pause, formal terminate on repeated read-only violations, refuse forced code generation, and refuse premature `/spdd-analysis` transition.
+   - `Core (The "Why")` mindset: curious, open paths, visual (Mermaid/ASCII/trade-off tables), patient, grounded in current code.
+   - `Distorted Mirror Technique`:
+     - Every 3–4 interactions, reflect understanding while deliberately injecting 1–2 plausible unconfirmed assumptions.
+     - Include the login/OAuth2 vs JWT example from the requirement.
+     - Rules: plausible distortions, do not announce the test, reveal tacit assumptions, never use to confirm complex architectures.
+   - `Micro Action Segments` executed on demand:
+     - M1 Explore the Problem Space
+     - M2 Investigate the Codebase
+     - M3 Compare Options (max 3 approaches; Performance/Maintainability/Scalability)
+     - M4 Expose Risks and Uncertainties
+   - `Transition Checkpoint` requiring ALL conditions before suggesting `/spdd-analysis`:
+     - `problem_defined = TRUE`
+     - `direction_chosen = TRUE`
+     - `uncertainties_mitigated = TRUE`
+     - `codebase_mapped = TRUE`
+     - `distorted_mirror_applied = TRUE`
+     - `implicit_assumptions = FALSE`
+     - Transition ask text: invite formalizing via `/spdd-analysis` to create the foundational strategic artifact.
+   - `Decision Log`: when consensus/decision is reached, create draft markdown at `spdd/explore/{timestamp}-[Explore]-{description}.md`.
+   - `Final Reminder`: do not rush discovery; explore ends when the user has enough insight to move forward.
+5. Constraints:
+   - File must live under `optional/`, never `core/`.
+   - Decision Log is the only authorized write surface called out by the template.
+6. Verification:
+   - `ListOptional()` includes `spdd-explore`.
+   - `ListCore()` and `ListAvailable(any tool)` do not include `spdd-explore`.
+   - `GetByName("spdd-explore")` and `GetByName("/spdd-explore")` succeed.
+   - Explicit generate of `spdd-explore` for Cursor writes `.cursor/commands/spdd-explore.md`; for Antigravity writes `.agents/workflows/spdd-explore.md`.
+
+### Update Documentation - Antigravity Path and Optional Explore
+1. Responsibility: keep user-facing docs aligned with detector mapping and optional explore availability.
+2. Files:
+   - `README.md`
+   - `README.zh-CN.md`
+3. Logic:
+   - In the supported-tools table, change Antigravity config/commands column from `.antigravity/commands/` to `.agents/workflows/`.
+   - Keep detection marker description as `.antigravity/` unless the table already distinguishes detection vs install path; if a single column mixes both, clarify detection = `.antigravity/` and install = `.agents/workflows/`.
+   - Add a brief migration note near tool-support docs: after upgrading, re-run generate for Antigravity; previous files under `.antigravity/commands/` are not moved automatically.
+   - Mention that `spdd-explore` is an optional template installable via optional listing/generation (wording consistent with existing optional-template docs if present; otherwise one short bullet).
+4. Constraints:
+   - Do not claim explore is installed by default.
+5. Verification:
+   - README EN/ZH no longer advertise Antigravity install path as `.antigravity/commands/`.
+
+### Update Tests - Detector, Manager, Strategies
+1. Responsibility: lock the new contracts and prevent regressions.
+2. Files to update/extend:
+   - `tests/detector/types_test.go`: Antigravity `GetConfigDir` expected value → `.agents/workflows`.
+   - `tests/detector/detector_test.go`: Antigravity detected `ConfigPath` expectations → `.../.agents/workflows`.
+   - `tests/templates/manager_test.go`: add/adjust coverage for optional `spdd-explore` presence; add slash-prefixed lookup compatibility for a core template and for `spdd-explore`.
+   - `tests/templates/types_test.go`: any fixture asserting `name: /spdd-generate` updated to slash-free form if it validates live corpus parsing expectations.
+   - `tests/templates/opencode_flat_strategy_test.go`:
+     - Keep using slash-prefixed `GetByName` if desired (must still work).
+     - Assertions that non-OpenCode output contains `name: /spdd-analysis` must change to `name: spdd-analysis`.
+     - OpenCode output must still contain no `name:` frontmatter key.
+   - `tests/templates/codex_strategy_test.go`: keep slash-prefixed lookups working; skill `name` remains slash-free.
+3. Constraints:
+   - Do not weaken OpenCode “no name key” assertions.
+   - Do not assert deletion or modification of `.agents/skills` when testing Antigravity paths.
+4. Verification:
+   - Full relevant packages pass: `tests/detector`, `tests/templates`, and any cmd tests that embed Antigravity config paths.
+
+## Norms
+1. Embedded Template Standards:
+   - Frontmatter keys remain `name`, `id`, `category`, `description`.
+   - `name` must equal `id` with no leading `/` for all core and optional SPDD command templates.
+   - `id` remains the filename stem and generation basename.
+2. Corpus Placement:
+   - Mandatory pipeline commands stay in `data/core/`.
+   - Situational/pre-analysis/post-validation commands stay in `data/optional/`.
+   - Explore Mode is optional by definition.
+3. Detector Mapping:
+   - `GetConfigDir()` returns relative directory paths without leading or trailing slashes.
+   - Shared parent directories (`.agents`) may host multiple tool children; operations must target the leaf config dir only.
+4. Lookup Compatibility:
+   - Public template lookup accepts both slash-prefixed and slash-free names via input normalization, not by mutating stored metadata.
+5. Strategy Boundaries:
+   - Tool-specific output quirks stay in adapters/strategies (OpenCode strip-name, Codex skill transform).
+   - Shared source templates remain the single corpus.
+6. Documentation Standards:
+   - EN and ZH README tool tables must stay path-accurate after detector changes.
+   - Optional templates must be labeled optional in docs when newly introduced.
+7. Testing Standards:
+   - Path mapping changes require table-driven detector expectation updates in the same change set.
+   - Frontmatter standardization requires at least one positive slash-prefixed lookup test and one OpenCode no-`name` regression test.
+
+## Safeguards
+1. Functional Constraints:
+   - `spdd-explore` MUST exist under `internal/templates/data/optional/spdd-explore.md` and MUST NOT exist under `data/core/`.
+   - Explore template MUST forbid implementable code generation and product-file mutation, with the sole write exception `spdd/explore/{timestamp}-[Explore]-{description}.md`.
+   - Explore template MUST include Distorted Mirror Technique, M1–M4, and the six-condition transition checkpoint before suggesting `/spdd-analysis`.
+2. Path Constraints:
+   - `detector.Antigravity.GetConfigDir()` MUST return exactly `.agents/workflows`.
+   - Antigravity generate/init/uninstall MUST NOT delete or rewrite `.agents/skills` or other non-workflows children of `.agents`.
+   - Antigravity `GetSignatureFiles()` remains `.antigravity` in this change set.
+3. Metadata Constraints:
+   - After standardization, no file in `data/core/` or `data/optional/` may contain a frontmatter line starting with `name: /`.
+   - `GetByName("/spdd-analysis")` and `GetByName("spdd-analysis")` MUST both succeed.
+   - `GetByName("/spdd-explore")` and `GetByName("spdd-explore")` MUST both succeed.
+4. Compatibility Constraints:
+   - OpenCode generated command files MUST continue to omit the `name` frontmatter key.
+   - Codex skill generation MUST continue to emit slash-free skill names and skill-bundle layout.
+   - Non-Antigravity config directories MUST remain unchanged.
+5. Documentation Constraints:
+   - README.md and README.zh-CN.md MUST document Antigravity install path as `.agents/workflows/` (or equivalent localized wording).
+   - Docs MUST NOT claim `spdd-explore` is part of default core install.
+6. Scope Constraints:
+   - Do not introduce a Go runtime that enforces Explore Mode transition gates.
+   - Do not auto-migrate stale `.antigravity/commands` files; document regeneration instead.
+   - Do not reverse GGQPA-006 by removing `OpenCodeTemplateAdapter`; keep it.
+7. Quality Constraints:
+   - Detector and templates test packages covering touched contracts MUST pass after the change.
+   - No placeholders or incomplete explore policy sections are allowed in `spdd-explore.md`.

--- a/tests/detector/detector_test.go
+++ b/tests/detector/detector_test.go
@@ -109,8 +109,8 @@ func TestDefaultDetector_Detect_AntigravityEnvironment(t *testing.T) {
 	if result.ToolType != detector.Antigravity {
 		t.Errorf("Detect() ToolType = %v, want %v", result.ToolType, detector.Antigravity)
 	}
-	if result.ConfigPath != filepath.Join(tempDir, ".antigravity/commands") {
-		t.Errorf("Detect() ConfigPath = %v, want %v", result.ConfigPath, filepath.Join(tempDir, ".antigravity/commands"))
+	if result.ConfigPath != filepath.Join(tempDir, ".agents/workflows") {
+		t.Errorf("Detect() ConfigPath = %v, want %v", result.ConfigPath, filepath.Join(tempDir, ".agents/workflows"))
 	}
 }
 
@@ -421,7 +421,7 @@ func TestDefaultDetector_GetConfigDirPath(t *testing.T) {
 			name:       "Antigravity config path",
 			tool:       detector.Antigravity,
 			workingDir: "/project",
-			want:       "/project/.antigravity/commands",
+			want:       "/project/.agents/workflows",
 		},
 		{
 			name:       "GitHubCopilot config path",

--- a/tests/detector/types_test.go
+++ b/tests/detector/types_test.go
@@ -82,7 +82,7 @@ func TestAIToolType_GetConfigDir(t *testing.T) {
 		{
 			name:     "Antigravity config directory",
 			toolType: detector.Antigravity,
-			want:     ".antigravity/commands",
+			want:     ".agents/workflows",
 		},
 		{
 			name:     "GitHubCopilot config directory",

--- a/tests/templates/manager_test.go
+++ b/tests/templates/manager_test.go
@@ -282,6 +282,102 @@ func TestEmbeddedTemplateManager_GetByName_NotFound(t *testing.T) {
 	}
 }
 
+func TestEmbeddedTemplateManager_GetByName_SlashPrefixedCompatibility(t *testing.T) {
+	manager := templates.NewEmbeddedTemplateManager()
+
+	slashFree, err := manager.GetByName("spdd-analysis")
+	if err != nil {
+		t.Fatalf("GetByName('spdd-analysis') error = %v", err)
+	}
+	slashPrefixed, err := manager.GetByName("/spdd-analysis")
+	if err != nil {
+		t.Fatalf("GetByName('/spdd-analysis') error = %v", err)
+	}
+	if slashFree.ID != slashPrefixed.ID {
+		t.Errorf("slash-free and slash-prefixed lookup IDs differ: %q vs %q", slashFree.ID, slashPrefixed.ID)
+	}
+	if slashFree.ID != "spdd-analysis" {
+		t.Errorf("GetByName() ID = %v, want spdd-analysis", slashFree.ID)
+	}
+}
+
+func TestEmbeddedTemplateManager_ListOptional_IncludesExplore(t *testing.T) {
+	manager := templates.NewEmbeddedTemplateManager()
+	tmpls, err := manager.ListOptional()
+	if err != nil {
+		t.Fatalf("ListOptional() error = %v", err)
+	}
+
+	found := false
+	for _, tmpl := range tmpls {
+		if tmpl.ID == "spdd-explore" {
+			found = true
+			if tmpl.Name != "spdd-explore" {
+				t.Errorf("spdd-explore Name = %q, want spdd-explore (slash-free)", tmpl.Name)
+			}
+			if strings.HasPrefix(tmpl.Name, "/") {
+				t.Errorf("spdd-explore Name must not start with /: %q", tmpl.Name)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("ListOptional() should include spdd-explore")
+	}
+
+	core, err := manager.ListCore()
+	if err != nil {
+		t.Fatalf("ListCore() error = %v", err)
+	}
+	for _, tmpl := range core {
+		if tmpl.ID == "spdd-explore" {
+			t.Error("ListCore() must not include spdd-explore")
+		}
+	}
+
+	available, err := manager.ListAvailable(detector.Cursor)
+	if err != nil {
+		t.Fatalf("ListAvailable(Cursor) error = %v", err)
+	}
+	for _, tmpl := range available {
+		if tmpl.ID == "spdd-explore" {
+			t.Error("ListAvailable() must not include optional spdd-explore")
+		}
+	}
+
+	explore, err := manager.GetByName("/spdd-explore")
+	if err != nil {
+		t.Fatalf("GetByName('/spdd-explore') error = %v", err)
+	}
+	if explore.ID != "spdd-explore" {
+		t.Errorf("GetByName('/spdd-explore') ID = %v, want spdd-explore", explore.ID)
+	}
+}
+
+func TestEmbeddedTemplateManager_CoreAndOptionalNamesAreSlashFree(t *testing.T) {
+	manager := templates.NewEmbeddedTemplateManager()
+
+	core, err := manager.ListCore()
+	if err != nil {
+		t.Fatalf("ListCore() error = %v", err)
+	}
+	for _, tmpl := range core {
+		if strings.HasPrefix(tmpl.Name, "/") {
+			t.Errorf("core template %s Name must be slash-free, got %q", tmpl.ID, tmpl.Name)
+		}
+	}
+
+	optional, err := manager.ListOptional()
+	if err != nil {
+		t.Fatalf("ListOptional() error = %v", err)
+	}
+	for _, tmpl := range optional {
+		if strings.HasPrefix(tmpl.Name, "/") {
+			t.Errorf("optional template %s Name must be slash-free, got %q", tmpl.ID, tmpl.Name)
+		}
+	}
+}
+
 func TestEmbeddedTemplateManager_Generate_Success(t *testing.T) {
 	tempDir := t.TempDir()
 	targetPath := filepath.Join(tempDir, "test-output.md")

--- a/tests/templates/opencode_flat_strategy_test.go
+++ b/tests/templates/opencode_flat_strategy_test.go
@@ -93,7 +93,7 @@ func TestFlatMarkdownStrategy_NonOpenCode_PreservesFrontmatterName(t *testing.T)
 	}
 	content := string(raw)
 
-	if !strings.Contains(content, "name: /spdd-analysis") {
+	if !strings.Contains(content, "name: spdd-analysis") {
 		t.Fatalf("non-OpenCode generation should preserve name field")
 	}
 }

--- a/tests/templates/types_test.go
+++ b/tests/templates/types_test.go
@@ -180,7 +180,7 @@ func TestParseFrontmatter_EmptyContent(t *testing.T) {
 
 func TestParseFrontmatter_RealWorldTemplate(t *testing.T) {
 	content := `---
-name: /spdd-generate
+name: spdd-generate
 id: spdd-generate
 category: Development
 description: Generate code from a structured SPDD prompt file following the REASONS Canvas methodology
@@ -192,8 +192,8 @@ Generate implementation code from a structured SPDD (Structured Prompt-Driven De
 
 	meta := templates.ParseFrontmatter(content)
 
-	if meta.Name != "/spdd-generate" {
-		t.Errorf("ParseFrontmatter() Name = %v, want %v", meta.Name, "/spdd-generate")
+	if meta.Name != "spdd-generate" {
+		t.Errorf("ParseFrontmatter() Name = %v, want %v", meta.Name, "spdd-generate")
 	}
 	if meta.ID != "spdd-generate" {
 		t.Errorf("ParseFrontmatter() ID = %v, want %v", meta.ID, "spdd-generate")


### PR DESCRIPTION
…dize template metadata

- Introduced a new optional command `spdd-explore` to facilitate a read-only exploration phase for users before formal analysis.
- Updated the Antigravity configuration directory to `.agents/workflows` for better alignment with existing workflows.
- Standardized template metadata by removing leading slashes from the `name` fields of core and optional templates, ensuring compatibility with existing lookup methods.
- Updated documentation to reflect these changes and included migration notes for users upgrading from previous versions.