### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=gszhangwei%2Fopen-spdd&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#gszhangwei/open-spdd&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=gszhangwei/open-spdd&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=gszhangwei/open-spdd&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,11 +8,11 @@ OpenSPDD 是一套面向 AI 编码时代的结构化提示词驱动开发方法�
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=gszhangwei%2Fopen-spdd&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#gszhangwei/open-spdd&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=gszhangwei/open-spdd&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=gszhangwei/open-spdd&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=gszhangwei/open-spdd&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken, showing nothing due to upstream API restrictions on GitHub stargazer data. This change moves the chart to a working mirror that uses an alternative data source requiring no API token, so visitors can see the project's growth again.

Updated both README.md and README.zh-CN.md to point at the new, working chart location.